### PR TITLE
Fixed the "share on tweetdeck" context menu not working

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,8 @@
     "editor.formatOnSave": true
   },
   "[json]": {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "vscode.json-language-features"
   },
   "[markdown]": {
     "editor.formatOnSave": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bettertweetdeck",
-  "version": "4.11.1",
+  "version": "4.11.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bettertweetdeck",
-      "version": "4.11.1",
+      "version": "4.11.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bettertweetdeck",
-  "version": "4.11.2",
+  "version": "4.11.3",
   "description": "Adds some nice options on TweetDeck.",
   "repository": {
     "type": "git",

--- a/safari/Better TweetDeck for Safari/Better TweetDeck for Safari Extension/Info.plist
+++ b/safari/Better TweetDeck for Safari/Better TweetDeck for Safari Extension/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundleShortVersionString</key>
     <string>$(MARKETING_VERSION)</string>
     <key>CFBundleVersion</key>
-    <string>2312181613</string>
+    <string>2312181630</string>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
     <key>LSMinimumSystemVersion</key>

--- a/safari/Better TweetDeck for Safari/Better TweetDeck for Safari Extension/Info.plist
+++ b/safari/Better TweetDeck for Safari/Better TweetDeck for Safari Extension/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundleShortVersionString</key>
     <string>$(MARKETING_VERSION)</string>
     <key>CFBundleVersion</key>
-    <string>2302062322</string>
+    <string>2312181613</string>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
     <key>LSMinimumSystemVersion</key>

--- a/safari/Better TweetDeck for Safari/Better TweetDeck for Safari/Info.plist
+++ b/safari/Better TweetDeck for Safari/Better TweetDeck for Safari/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundleShortVersionString</key>
     <string>$(MARKETING_VERSION)</string>
     <key>CFBundleVersion</key>
-    <string>2312181613</string>
+    <string>2312181630</string>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
     <key>LSApplicationCategoryType</key>

--- a/safari/Better TweetDeck for Safari/Better TweetDeck for Safari/Info.plist
+++ b/safari/Better TweetDeck for Safari/Better TweetDeck for Safari/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundleShortVersionString</key>
     <string>$(MARKETING_VERSION)</string>
     <key>CFBundleVersion</key>
-    <string>2302062322</string>
+    <string>2312181613</string>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
     <key>LSApplicationCategoryType</key>

--- a/safari/Better TweetDeck for Safari/BetterTDeck for TweetDeck.xcodeproj/project.pbxproj
+++ b/safari/Better TweetDeck for Safari/BetterTDeck for TweetDeck.xcodeproj/project.pbxproj
@@ -418,7 +418,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 4.11.2;
+				MARKETING_VERSION = 4.11.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "me.erambert.bettertweetdeck-safari.extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -442,7 +442,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 4.11.2;
+				MARKETING_VERSION = 4.11.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "me.erambert.bettertweetdeck-safari.extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -469,7 +469,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 4.11.2;
+				MARKETING_VERSION = 4.11.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "me.erambert.bettertweetdeck-safari";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -495,7 +495,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 4.11.2;
+				MARKETING_VERSION = 4.11.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "me.erambert.bettertweetdeck-safari";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/safari/Better TweetDeck for Safari/BetterTDeck for TweetDeck.xcodeproj/project.pbxproj
+++ b/safari/Better TweetDeck for Safari/BetterTDeck for TweetDeck.xcodeproj/project.pbxproj
@@ -418,7 +418,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 4.10.1;
+				MARKETING_VERSION = 4.11.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "me.erambert.bettertweetdeck-safari.extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -442,7 +442,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 4.10.1;
+				MARKETING_VERSION = 4.11.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "me.erambert.bettertweetdeck-safari.extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -469,7 +469,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 4.10.1;
+				MARKETING_VERSION = 4.11.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "me.erambert.bettertweetdeck-safari";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -495,7 +495,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 4.10.1;
+				MARKETING_VERSION = 4.11.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "me.erambert.bettertweetdeck-safari";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/src/background.ts
+++ b/src/background.ts
@@ -125,7 +125,7 @@ browser.contextMenus.onClicked.addListener(async (info, tab) => {
     : baseText.slice(0, textLimitWithLink) + suffix;
 
   const tabs = await browser.tabs.query({
-    url: '*://tweetdeck.twitter.com/*',
+    url: '*://twitter.com/i/tweetdeck*',
   });
 
   if (tabs.length === 0) {

--- a/src/background.ts
+++ b/src/background.ts
@@ -28,7 +28,7 @@ browser.runtime.onInstalled.addListener(async () => {
     }
 
     const tabs = await browser.tabs.query({
-      url: '*://tweetdeck.twitter.com/*',
+      url: '*://twitter.com/i/tweetdeck*',
     });
 
     if (tabs.length > 0) {


### PR DESCRIPTION
the OG BTD has a feature that allows us to share an article or webpage with right clicking on it and selecting "share on tweetdeck" in the context menu. That should open the tweetdeck tab and populate the tweet editor with the title and url of the page. However, it's not working with the oldtweetdeck version. That would be because it's looking for the tab with the url of the official tweedeck (tweetdeck.twitter.com) instead of the OTD one which is twitter.com/i/tweetdeck.

changing that should fix it (*haven't tested it yet, this is my first PR ever, very new to this)