### PR TITLE
Change Update Pop-up to link to dimdenGD GitHub

### DIFF
--- a/src/services/setupBTDNotifications.tsx
+++ b/src/services/setupBTDNotifications.tsx
@@ -211,7 +211,7 @@ const Notifications = () => {
         actions: {
           dismissLabel: 'Got it',
           actionLabel: 'See changes',
-          href: `https://github.com/eramdam/BetterTweetDeck/releases/tag/${getExtensionVersion()}`,
+          href: `https://github.com/dimdenGD/BetterTweetDeck/releases/tag/${getExtensionVersion()}`,
         },
         icon: <Icon.Bell />,
       };

--- a/src/services/setupBTDNotifications.tsx
+++ b/src/services/setupBTDNotifications.tsx
@@ -211,7 +211,7 @@ const Notifications = () => {
         actions: {
           dismissLabel: 'Got it',
           actionLabel: 'See changes',
-          href: `https://github.com/dimdenGD/BetterTweetDeck/releases/tag/${getExtensionVersion()}`,
+          href: `https://github.com/dimdenGD/BetterTweetDeck/releases/tag/v${getExtensionVersion()}`,
         },
         icon: <Icon.Bell />,
       };


### PR DESCRIPTION
Clicking on the new release popup "see changes" button will now properly link to dimdenGD's GitHub release
